### PR TITLE
Alltrips is only public

### DIFF
--- a/src/components/AllTripsCard/AllTripsCard.jsx
+++ b/src/components/AllTripsCard/AllTripsCard.jsx
@@ -14,11 +14,11 @@ const AllTripsCard = ({trip}) => {
         <header className={styles.text}>
           <span>
             <h1>{trip.name}</h1>
-            <h2>{trip.destination}</h2>
-            <h3>{trip.date}</h3>
           </span>
+            <h6>{trip.startDate}</h6>
         </header>
         <p className={styles.text}>{trip.description}</p>
+        {trip.private?<p>(Visbility: Private)</p>:<></>}
       </article>
     </Link>
   );

--- a/src/pages/AllTrips/AllTrips.jsx
+++ b/src/pages/AllTrips/AllTrips.jsx
@@ -15,9 +15,9 @@ const AllTrips = (props) => {
 
         <main className={styles.container}>
           {props.trips.map(trip =>
-
-            <AllTripsCard key={trip?._id} trip={trip} />
-            
+            !trip.private
+              ? <AllTripsCard key={trip?._id} trip={trip} />
+              : <></>
             
 
           )}


### PR DESCRIPTION
This makes the all trips page only show a card for public trips.
The my trips page will show your private trips with a tag labeling them as private better explaining why your trip doesn't appear on the all trips page.
Also fixed issue with the trip date not appearing on the card due to a typo.